### PR TITLE
Warnings throwing on WC_Gateway_Simplify_Commerce_Loader::__wakeup().

### DIFF
--- a/woocommerce-simplify-payment-gateway.php
+++ b/woocommerce-simplify-payment-gateway.php
@@ -68,7 +68,7 @@ class WC_Gateway_Simplify_Commerce_Loader {
 	 *
 	 * @return void
 	 */
-	private function __wakeup() {
+	public function __wakeup() {
 	}
 
 	/** @var whether or not we need to load code for / support subscriptions */


### PR DESCRIPTION
Endless warning messages show up in error log file while running on PHP 8.

The magic method WC_Gateway_Simplify_Commerce_Loader::__wakeup() must have public visibility in ../wp-content/plugins/woocommerce-simplify-payment-gateway-plugin-2.2.0/woocommerce-simplify-payment-gateway.php on line 71.

Warnings goes away when set to public. Please check this, as in cases of high traffic, error logs is on fire.
Although this is a minor lets say warning, it doesn't mean nobody has to deal with this, right?